### PR TITLE
c10-44 correcion de dato en seed

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -156,7 +156,7 @@ async function main() {
         data: [
             {country: 'Estados Unidos'},
             {country: 'Union Europea'},
-            {country: 'Mi pais de residencia actual'},
+            {country: 'Mi pais de origen'},
             {country: 'Otros paises'}
         ]
     });


### PR DESCRIPTION
Actualización incidencia c10-44 se cambio de script bashscript por función integrada de prisma "seed":

**Archivos nuevos**

_seed.ts_
- creado para ser usado en el sistema de poblado automático de prisma aquí van los registro que se crearan previamente
- **correcion de campo en seed por problema en db, se sobre pasa el limite de caracteres**

**Archivos eliminado**

_population_tables.sh_
- se elimino a favor del uso del archivos seed.ts

**Modificacion de archivos**

_.gitignore_ 
- se restableció a su estado anterior

_docker-compose.yml_ 
- se devolvio a su estado anterior eliminado volumes de ambos containers

_package.json_
- se eliminaron compandos para user bashscript
- se agrego clave para usar el sistema de semillas de prisma
- se agrego script para correr la semilla con clave db:(test/dev):seed
- se agregaron los script para db:(test/dev):seed a el script db:(test/dev):restart